### PR TITLE
Support a custom reducer when using infix_expression

### DIFF
--- a/lib/parslet.rb
+++ b/lib/parslet.rb
@@ -217,6 +217,10 @@ module Parslet
   # associativity is chosen, it would be interpreted as '1 + (2 + 3)'. Note 
   # that the hash trees output reflect that choice as well. 
   #
+  # An optional block can be provided in order to manipulate the generated tree.
+  # The block will be called on each operator and passed 3 arguments: the left
+  # operand, the operator, and the right operand.
+  #
   # Example:
   #   infix_expression(integer, [add_op, 1, :left])
   #   # would parse things like '1 + 2'
@@ -227,8 +231,8 @@ module Parslet
   #  
   # @see Parslet::Atoms::Infix
   #
-  def infix_expression(element, *operations)
-    Parslet::Atoms::Infix.new(element, operations)
+  def infix_expression(element, *operations, &reducer)
+    Parslet::Atoms::Infix.new(element, operations, &reducer)
   end
   module_function :infix_expression
   

--- a/lib/parslet/atoms/infix.rb
+++ b/lib/parslet/atoms/infix.rb
@@ -1,11 +1,12 @@
 class Parslet::Atoms::Infix < Parslet::Atoms::Base
-  attr_reader :element, :operations
+  attr_reader :element, :operations, :reducer
 
-  def initialize(element, operations)
+  def initialize(element, operations, &reducer)
     super()
 
     @element = element
     @operations = operations
+    @reducer = reducer || lambda { |left, op, right| {l: left, o: op, r: right} }
   end
   
   def try(source, context, consume_all)
@@ -31,9 +32,9 @@ class Parslet::Atoms::Infix < Parslet::Atoms::Base
 
       if right.kind_of? Array
         # Subexpression -> Subhash
-        left = {l: left, o: op, r: produce_tree(right)}
+        left = reducer.call(left, op, produce_tree(right))
       else
-        left = {l: left, o: op, r: right}
+        left = reducer.call(left, op, right)
       end
     end
 

--- a/spec/acceptance/infix_parser_spec.rb
+++ b/spec/acceptance/infix_parser_spec.rb
@@ -109,4 +109,13 @@ Don't know what to do with "%" at line 1 char 2.
       end
     end
   end
+  describe "providing a reducer block" do
+    class InfixExpressionReducerParser < Parslet::Parser
+      rule(:top) { infix_expression(str('a'), [str('-'), 1, :right]) { |l,o,r| {:and=>[l,r]} } }
+    end
+    
+    it "applies the reducer" do
+      InfixExpressionReducerParser.new.top.parse("a-a-a").should == {:and=>["a", {:and=>["a", "a"]}]}
+    end
+  end
 end


### PR DESCRIPTION
This adds support for a custom reducer when using `infix_expression`. This allows you to change the way the tree is generated:

```
p = infix_expression(str('a'), [str('-'), 1, :right]) { |l,o,r| {:and=>[l,r]} }
p.parse("a-a-a")
# => {:and=>["a", {:and=>["a", "a"]}]}
# instead of {:l=>"a", :o=>"-", :r=>{:l=>"a", :o=>"-", :r=>"a"}}
```

This is more convenient that using `Transform`s because the reducer here is bundled with the parser and will follow the parser wherever the parser is used (more composable). Also, the reducer will only be applied to exactly the nodes of the tree where an infix expression occurs (not the whole tree).
